### PR TITLE
Fix wrong satellite miss detection

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -534,3 +534,4 @@ VDR Plugin 'wirbelscan' Revision History
   cWirbelscanScanSetup named SignalWaitTime and LockTimeout are available in the
   controlling plugin.
 * TP update on S19E2
+* improve wrong satellite miss detection with some NIT tables

--- a/scanfilter.cpp
+++ b/scanfilter.cpp
@@ -837,8 +837,7 @@ void cNitScanner::Process(const unsigned char* Data, int Length) {
               transponder->DelSys = System;
               transponder->Rolloff = RollOff;
               transponder->OrbitalPos = BCDtoDecimal(sd->getOrbitalPosition());
-              if (!sd->getWestEastFlag())
-                 transponder->OrbitalPos *= -1;
+              transponder->West = west_flag;
 
               bool found = false;
               for(int i = 0; !found and i < data.transport_streams.Count(); i++) {

--- a/statemachine.cpp
+++ b/statemachine.cpp
@@ -376,8 +376,9 @@ void cStateMachine::Action(void) {
                  NitData.transport_streams[i]->reported = true;
                  NitData.transport_streams[i]->PrintTransponder(s);
                  std::string is_wrong;
-                 if (abs(NitData.transport_streams[i]->OrbitalPos - initial->OrbitalPos) > 5)
-                    is_wrong = "WRONG SATELLITE: ";
+                 if ( (abs(NitData.transport_streams[i]->OrbitalPos - initial->OrbitalPos) > 5) &&
+                      (NitData.transport_streams[i]->OrbitalPos != -(initial->OrbitalPos)) )
+                    is_wrong = "WRONG SATELLITE ( " + IntToStr(initial->OrbitalPos) + " | " + IntToStr(NitData.transport_streams[i]->OrbitalPos) + " ): ";
                  dlog(0, "NIT: " + is_wrong + "'" + s + "'" + 
                          ", NID = "  + IntToStr(NitData.transport_streams[i]->NID)  +
                          ", ONID = " + IntToStr(NitData.transport_streams[i]->ONID) +

--- a/statemachine.cpp
+++ b/statemachine.cpp
@@ -376,8 +376,7 @@ void cStateMachine::Action(void) {
                  NitData.transport_streams[i]->reported = true;
                  NitData.transport_streams[i]->PrintTransponder(s);
                  std::string is_wrong;
-                 if ( (abs(NitData.transport_streams[i]->OrbitalPos - initial->OrbitalPos) > 5) &&
-                      (NitData.transport_streams[i]->OrbitalPos != -(initial->OrbitalPos)) )
+                 if (abs(NitData.transport_streams[i]->OrbitalPos - initial->OrbitalPos) > 5)
                     is_wrong = "WRONG SATELLITE ( " + IntToStr(initial->OrbitalPos) + " | " + IntToStr(NitData.transport_streams[i]->OrbitalPos) + " ): ";
                  dlog(0, "NIT: " + is_wrong + "'" + s + "'" + 
                          ", NID = "  + IntToStr(NitData.transport_streams[i]->NID)  +


### PR DESCRIPTION
In some NIT tables the orbital position has a negative value. This patch solves it and it adds more useful information in the log message "WRONG SATELLITE".