### PR TITLE
Initialize empty lang descriptor

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -534,3 +534,4 @@ VDR Plugin 'wirbelscan' Revision History
   cWirbelscanScanSetup named SignalWaitTime and LockTimeout are available in the
   controlling plugin.
 * TP update on S19E2
+* fixed the case when a language descriptor is empty (random incorrect lang)

--- a/scanfilter.cpp
+++ b/scanfilter.cpp
@@ -385,6 +385,7 @@ void cPmtScanner::Process(const unsigned char* Data, int Length) {
                     SI::ISO639LanguageDescriptor* ld = (SI::ISO639LanguageDescriptor*) d;
                     SI::ISO639LanguageDescriptor::Language l;
                     char b[16], *s = b;
+                    b[0] = '\0'; // Warning: Initialize as empty string!
                     int n = 0;
                     for(SI::Loop::Iterator it; ld->languageLoop.getNext(l, it);) {
                        if (*ld->languageCode != '-') {
@@ -426,6 +427,7 @@ void cPmtScanner::Process(const unsigned char* Data, int Length) {
                     break;
                  case SI::SubtitlingDescriptorTag: {
                     char b[16], *s = b;
+                    b[0] = '\0'; // Warning: Initialize as empty string!
                     TPid spid;
                     spid.PID = stream.getPid();
                     SI::SubtitlingDescriptor* sd = (SI::SubtitlingDescriptor*) d;

--- a/scanfilter.cpp
+++ b/scanfilter.cpp
@@ -384,8 +384,7 @@ void cPmtScanner::Process(const unsigned char* Data, int Length) {
                  case SI::ISO639LanguageDescriptorTag: {
                     SI::ISO639LanguageDescriptor* ld = (SI::ISO639LanguageDescriptor*) d;
                     SI::ISO639LanguageDescriptor::Language l;
-                    char b[16], *s = b;
-                    b[0] = '\0'; // Warning: Initialize as empty string!
+                    char b[16] = {0}, *s = b;
                     int n = 0;
                     for(SI::Loop::Iterator it; ld->languageLoop.getNext(l, it);) {
                        if (*ld->languageCode != '-') {
@@ -426,8 +425,7 @@ void cPmtScanner::Process(const unsigned char* Data, int Length) {
                     dpid.Type = d->getDescriptorTag();
                     break;
                  case SI::SubtitlingDescriptorTag: {
-                    char b[16], *s = b;
-                    b[0] = '\0'; // Warning: Initialize as empty string!
+                    char b[16] = {0}, *s = b;
                     TPid spid;
                     spid.PID = stream.getPid();
                     SI::SubtitlingDescriptor* sd = (SI::SubtitlingDescriptor*) d;


### PR DESCRIPTION
Fixing the case where a language descriptor does not contain any entries. In this case the code was random.