### PR TITLE
Add configuration to Enable/Disable T2 modulations

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -535,3 +535,4 @@ VDR Plugin 'wirbelscan' Revision History
   controlling plugin.
 * TP update on S19E2
 * fixed the case when a language descriptor is empty (random incorrect lang)
+* add support for configuring the use of gen2 modulations with DVB-T/T2 tuners

--- a/common.h
+++ b/common.h
@@ -224,7 +224,7 @@ public:
   int DVBC_Network_PID;
   int CountryIndex;
   int SatIndex;
-  int enable_s2;
+  int enable_s2;  /* Includes S2 & T2 */
   int ATSC_type;
   uint32_t scanflags;
   bool update;

--- a/scanner.cpp
+++ b/scanner.cpp
@@ -447,12 +447,14 @@ void cScanner::Action(void) {
            }
         if (t2Support)
            dlog(5, "DVB-T2 supported");
-        else
+        else {
+           wSetup.enable_s2 = false;
            dlog(0, "WARN: you are using an outdated DVB device: no DVB-T2 support.");
+           }
 
         // use mod as system T/T2 to avoid a further loop.
         // min = T2, max = T
-        modulation_min = t2Support ? 0 : 1;
+        modulation_min = (t2Support && wSetup.enable_s2) ? 0 : 1;
         modulation_max = 1;
         sys_parm = 0;
         // use srate as plp 0/1 to avoid a further loop.


### PR DESCRIPTION
This simple patch promotes the use of the 'enable_s2' flag for the TERRESTRIAL modulation too. By default DVB-T2 is enabled, but now it's available the configuration option to disable it and use only DVB-T. This behavior is identical to that of DVB-S. 