### PR TITLE
Fix compile error with some compilers

### DIFF
--- a/scanfilter.cpp
+++ b/scanfilter.cpp
@@ -586,7 +586,7 @@ void swap(TFrequencyListItem& a, TFrequencyListItem& b) {
 }
 
 /* std::sort */
-bool TChannelListItem::operator < (const TChannelListItem& rhs) {
+bool TChannelListItem::operator < (const TChannelListItem& rhs) const {
   if (channel_list_id != rhs.channel_list_id)
      return channel_list_id < rhs.channel_list_id;
 
@@ -606,7 +606,7 @@ bool TChannelListItem::operator < (const TChannelListItem& rhs) {
 }
 
 /* std::unique */
-bool TChannelListItem::operator == (const TChannelListItem& rhs) {
+bool TChannelListItem::operator == (const TChannelListItem& rhs) const {
   return
     ( channel_list_id     == rhs.channel_list_id     ) and
     ( original_network_id == rhs.original_network_id ) and

--- a/scanfilter.h
+++ b/scanfilter.h
@@ -97,8 +97,8 @@ struct TChannelListItem {
   bool HD_simulcast;
   int LCN;
   int LCN_minor;
-  bool operator <(const TChannelListItem& rhs);
-  bool operator==(const TChannelListItem& rhs);
+  bool operator <(const TChannelListItem& rhs) const;
+  bool operator==(const TChannelListItem& rhs) const;
 };
 
 // returns true, if GetLCN() assigned a new LCN to 'c'.


### PR DESCRIPTION
Hi @wirbel-at-vdr-portal ,

This patch fixes one compilation error with some compilers. The problem is inside the boolean operators. You're using the "this" reference, with the const parameter of the other instance. However, if you don't declare the function const the compiler doesn't work because the "this" pointer is not considered const.

This simple change fixes this compilation error.
I hope you want to merge it.
